### PR TITLE
tests: update dev dependency `webmock`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.0.8
+ - Update _development_ dependency webmock to latest version to prevent conflicts in logstash core's dependency matrix.
+
 ## 3.0.7
   - Docs: Set the default_codec doc attribute.
 

--- a/logstash-output-pagerduty.gemspec
+++ b/logstash-output-pagerduty.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-output-pagerduty'
-  s.version         = '3.0.7'
+  s.version         = '3.0.8'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Sends notifications based on preconfigured services and escalation policies"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"
@@ -24,6 +24,9 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'logstash-codec-plain'
 
   s.add_development_dependency 'logstash-devutils'
-  s.add_development_dependency 'webmock', '~> 1.21.0'
+
+  # Webmock 3.x requires Ruby >= 2.0, but Logstash 5.x still runs Ruby in 1.9-mode.
+  # Select the 3.x series where compatible, and fall back to webmock 2.2.x when necessary
+  s.add_development_dependency 'webmock', '>=2.2.0', '< 4.0.0'
 end
 


### PR DESCRIPTION
It appears as though transitive development dependencies of plugins we include with the Logstash distribution _silently override_ dependencies that are explicitly stated in the Logstash core's `Gemfile.template` during its `plugin:install-development-dependencies` task.

As such, this project being pinned to a very old version of webmock causes Logstash core to test with a very old version of webmock that is not fully compatible with JRuby 9.2.x; by pinning to the latest version, which works across all of the rubies we rely on in Logstash 5.x, 6.x, and beyond, we kick the can down the road.

I have opened a separate bug on Logstash core to address the whole _silent override_ thing: https://github.com/elastic/logstash/issues/10249