### PR TITLE
Update service_key to be dynamic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,11 @@ matrix:
   - rvm: jruby-9.1.13.0
     env: LOGSTASH_BRANCH=master
   - rvm: jruby-9.1.13.0
-    env: LOGSTASH_BRANCH=6.x
+    env: LOGSTASH_BRANCH=7.0
   - rvm: jruby-9.1.13.0
-    env: LOGSTASH_BRANCH=6.5
+    env: LOGSTASH_BRANCH=6.7
+  - rvm: jruby-9.1.13.0
+    env: LOGSTASH_BRANCH=6.6
   - rvm: jruby-1.7.27
     env: LOGSTASH_BRANCH=5.6
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,5 +17,5 @@ matrix:
   fast_finish: true
 install: true
 script: ci/build.sh
-jdk: oraclejdk8
+jdk: openjdk8
 before_install: gem install bundler -v '< 2'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.0.9
+ - Update service key to allow dynamic values.
+
 ## 3.0.8
  - Update _development_ dependency webmock to latest version to prevent conflicts in logstash core's dependency matrix.
 

--- a/lib/logstash/outputs/pagerduty.rb
+++ b/lib/logstash/outputs/pagerduty.rb
@@ -51,7 +51,7 @@ class LogStash::Outputs::PagerDuty < LogStash::Outputs::Base
     
 
     pd_event = Hash.new
-    pd_event[:service_key] = "#{@service_key}"
+    pd_event[:service_key] = event.sprintf(@service_key)
     pd_event[:incident_key] = event.sprintf(@incident_key)
     pd_event[:event_type] = "#{@event_type}"
     pd_event[:description] = event.sprintf(@description)

--- a/logstash-output-pagerduty.gemspec
+++ b/logstash-output-pagerduty.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-output-pagerduty'
-  s.version         = '3.0.8'
+  s.version         = '3.0.9'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Sends notifications based on preconfigured services and escalation policies"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
Many of the config options are already dynamic (e.g., incident_key,
description). This change allows the service key to be dynamic as well
in the case where multiple PagerDuty services might come from a single
logstash pipeline.

Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/
